### PR TITLE
output_chanels and loading

### DIFF
--- a/MTVulnerability/experiments/attacks/__init__.py
+++ b/MTVulnerability/experiments/attacks/__init__.py
@@ -39,16 +39,17 @@ def load_model(args):
 
         epoch = args.epoch
 
-        path_model = os.path.join(args.model_root, "savecheckpoint","checkpoint_{epoch}.pth.tar").format(
-                arch=args.arch,
-                dataset=args.dataset,
-                train="".join(train),
-                aux="".join(aux),
-                test="".join(test),
-                epoch=epoch
-        )
+        # path_model = os.path.join(args.model_root, "savecheckpoint","checkpoint_{epoch}.pth.tar").format(
+        #         arch=args.arch,
+        #         dataset=args.dataset,
+        #         train="".join(train),
+        #         aux="".join(aux),
+        #         test="".join(test),
+        #         epoch=epoch
+        # )
 
-        path_model=  path_model.replace("\r","")
+        # path_model=  path_model.replace("\r","")
+        path_model = args.model_root
 
         if args.dataset == "taskonomy" and args.arch == "resnet18":
                 model = resnet18_taskonomy(pretrained=False, tasks=args.test_task_set)
@@ -96,7 +97,7 @@ def load_model(args):
                 for k in ks:
                         state[k[7:]] = state.pop(k)
 
-        model.load_state_dict(state)  # , strict=False
+        model.load_state_dict(state, strict=False)  # , strict=False
         model = torch.nn.DataParallel(model)
         if torch.cuda.is_available():
                 model.cuda()

--- a/MTVulnerability/utils/xception_taskonomy_new.py
+++ b/MTVulnerability/utils/xception_taskonomy_new.py
@@ -320,7 +320,7 @@ class XceptionTaskonomy(nn.Module):
         if tasks is not None:
 
             task_to_params = {
-                'autoencoder': {'output_channels': 3},
+                'autoencoder': {'output_chanels': 3},
                 'class_object'      : {'output_chanels' : 0, 'num_cla sses':1000},
                 'class_places'       	: {'output_chanels' : 0, 'num_cla sses':63},
                 'depth_eucln'   	: {'output_chanels' : 1},
@@ -343,7 +343,7 @@ class XceptionTaskonomy(nn.Module):
             self.final_conv_bn = nn.BatchNorm2d(512)
             for task in tasks:
 
-                output_channels = task_to_params.get(task).get("output_channels", 0)
+                output_channels = task_to_params.get(task).get("output_chanels", 0)
                 nb_classes = task_to_params.get(task).get("num_classes", num_classes)
                 decoder = Decoder(output_channels, nb_classes,half_sized_output=half_sized_output)
                 self.task_to_decoder[task] = decoder


### PR DESCRIPTION
I was loading xception-full model and got an error:

```
taskaugment_venv/lib/python3.10/site-packages/torch/nn/init.py:405: UserWarning: Initializing zero-element tensors is a no-op
  warnings.warn("Initializing zero-element tensors is a no-op")
Traceback (most recent call last):
  File "taskaugment/MTVulnerability/experiments/attacks/adv_attack.py", line 110, in <module>
    run(args)
  File "taskaugment/MTVulnerability/experiments/attacks/adv_attack.py", line 58, in run
    model = load_model(args)
  File "taskaugment/MTVulnerability/experiments/attacks/__init__.py", line 77, in load_model
    model = XceptionTaskonomy(tasks=args.test_task_set)
  File "taskaugment/MTVulnerability/utils/xception_taskonomy_new.py", line 359, in __init__
    m.weight.data.normal_(0, math.sqrt(2. / n))
ZeroDivisionError: float division by zero
```


The error was an inconsistency in the variable  `chanels`. In some places was spelled `channels`. I made a small change so the variable is consistently spelled incorrectly :) Then, it was able to load.

Also, when loading `state_dict`, it did not work without the `strict` parameter being set to `True`. So, I used your comment.

Thanks!